### PR TITLE
Bug - stop termination for ArrayMove Events

### DIFF
--- a/src/server/adapter.cpp
+++ b/src/server/adapter.cpp
@@ -519,7 +519,8 @@ public:
         if (!m_list_property_name.size())
             return; // FIXME
 
-        REALM_TERMINATE("ArrayMove not supported by adapter.");
+        m_logger.warn("Adapter: Ignoring ArrayMove instruction");
+        return;
     }
 
     void operator()(const Instruction::ArraySwap&)


### PR DESCRIPTION
Fix a bug stop terminating app for receiving ArrayMove Events from realm - instead to print warning message of "Adapter: Ignoring ArrayMove instruction"